### PR TITLE
Add support for log lines of any size and glob patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added option to set up custom buffer size for the log reader. [#22](https://github.com/elastic/stream/pull/22)
+- Added support for glob patterns. [#22](https://github.com/elastic/stream/pull/22)
+
 ## [0.4.0]
 
 - Added HTTP Server output. [#19](https://github.com/elastic/stream/pull/19)

--- a/command/log.go
+++ b/command/log.go
@@ -39,12 +39,17 @@ func newLogRunner(options *output.Options, logger *zap.Logger) *cobra.Command {
 	return r.cmd
 }
 
-func (r *logRunner) Run(files []string) error {
+func (r *logRunner) Run(args []string) error {
 	out, err := output.Initialize(r.out, r.logger, r.cmd.Context())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
+
+	files, err := cmdutil.ExpandGlobPatternsFromArgs(args)
+	if err != nil {
+		return err
+	}
 
 	for _, f := range files {
 		if err := r.sendLog(f, out); err != nil {
@@ -66,6 +71,8 @@ func (r *logRunner) sendLog(path string, out output.Output) error {
 
 	var totalBytes, totalLines int
 	s := bufio.NewScanner(bufio.NewReader(f))
+	buf := make([]byte, r.out.LogReaderBuffer)
+	s.Buffer(buf, r.out.LogReaderBuffer)
 	for s.Scan() {
 		if r.cmd.Context().Err() != nil {
 			break

--- a/command/log.go
+++ b/command/log.go
@@ -71,8 +71,8 @@ func (r *logRunner) sendLog(path string, out output.Output) error {
 
 	var totalBytes, totalLines int
 	s := bufio.NewScanner(bufio.NewReader(f))
-	buf := make([]byte, r.out.LogReaderBuffer)
-	s.Buffer(buf, r.out.LogReaderBuffer)
+	buf := make([]byte, r.out.MaxLogLineSize)
+	s.Buffer(buf, r.out.MaxLogLineSize)
 	for s.Scan() {
 		if r.cmd.Context().Err() != nil {
 			break

--- a/command/root.go
+++ b/command/root.go
@@ -62,7 +62,7 @@ func ExecuteContext(ctx context.Context) error {
 	rootCmd.PersistentFlags().StringVarP(&opts.StartSignal, "start-signal", "s", "", "wait for start signal")
 	rootCmd.PersistentFlags().BoolVar(&opts.InsecureTLS, "insecure", false, "disable tls verification")
 	rootCmd.PersistentFlags().IntVar(&opts.RateLimit, "rate-limit", 500*1024, "bytes per second rate limit for UDP output")
-	rootCmd.PersistentFlags().IntVar(&opts.LogReaderBuffer, "log-reader-buf", 500*1024, "buffer size in bytes of the log reader")
+	rootCmd.PersistentFlags().IntVar(&opts.MaxLogLineSize, "max-log-line-size", 500*1024, "max size of a single log line in bytes")
 
 	// Webhook output flags.
 	rootCmd.PersistentFlags().StringVar(&opts.WebhookOptions.ContentType, "webhook-content-type", "application/json", "webhook Content-Type")

--- a/command/root.go
+++ b/command/root.go
@@ -62,6 +62,7 @@ func ExecuteContext(ctx context.Context) error {
 	rootCmd.PersistentFlags().StringVarP(&opts.StartSignal, "start-signal", "s", "", "wait for start signal")
 	rootCmd.PersistentFlags().BoolVar(&opts.InsecureTLS, "insecure", false, "disable tls verification")
 	rootCmd.PersistentFlags().IntVar(&opts.RateLimit, "rate-limit", 500*1024, "bytes per second rate limit for UDP output")
+	rootCmd.PersistentFlags().IntVar(&opts.LogReaderBuffer, "log-reader-buf", 500*1024, "buffer size in bytes of the log reader")
 
 	// Webhook output flags.
 	rootCmd.PersistentFlags().StringVar(&opts.WebhookOptions.ContentType, "webhook-content-type", "application/json", "webhook Content-Type")

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -7,13 +7,14 @@ package output
 import "time"
 
 type Options struct {
-	Addr        string        // Destination address (host:port).
-	Delay       time.Duration // Delay start after start signal.
-	Protocol    string        // Protocol (udp/tcp/tls).
-	Retries     int           // Number of connection retries for tcp based protocols.
-	StartSignal string        // OS signal to wait on before starting.
-	InsecureTLS bool          // Disable TLS verification checks.
-	RateLimit   int           // UDP rate limit in bytes.
+	Addr            string        // Destination address (host:port).
+	Delay           time.Duration // Delay start after start signal.
+	Protocol        string        // Protocol (udp/tcp/tls).
+	Retries         int           // Number of connection retries for tcp based protocols.
+	StartSignal     string        // OS signal to wait on before starting.
+	InsecureTLS     bool          // Disable TLS verification checks.
+	RateLimit       int           // UDP rate limit in bytes.
+	LogReaderBuffer int           // Log reader buffer size in bytes.
 
 	WebhookOptions
 	GCPPubsubOptions

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -7,14 +7,14 @@ package output
 import "time"
 
 type Options struct {
-	Addr            string        // Destination address (host:port).
-	Delay           time.Duration // Delay start after start signal.
-	Protocol        string        // Protocol (udp/tcp/tls).
-	Retries         int           // Number of connection retries for tcp based protocols.
-	StartSignal     string        // OS signal to wait on before starting.
-	InsecureTLS     bool          // Disable TLS verification checks.
-	RateLimit       int           // UDP rate limit in bytes.
-	LogReaderBuffer int           // Log reader buffer size in bytes.
+	Addr           string        // Destination address (host:port).
+	Delay          time.Duration // Delay start after start signal.
+	Protocol       string        // Protocol (udp/tcp/tls).
+	Retries        int           // Number of connection retries for tcp based protocols.
+	StartSignal    string        // OS signal to wait on before starting.
+	InsecureTLS    bool          // Disable TLS verification checks.
+	RateLimit      int           // UDP rate limit in bytes.
+	MaxLogLineSize int           // Log reader buffer size in bytes.
 
 	WebhookOptions
 	GCPPubsubOptions


### PR DESCRIPTION
Adds option to set up custom buffer size for the log reader.
Adds support for glob patterns.

Closes https://github.com/elastic/stream/issues/8