### PR TITLE
Add regular expression-based body matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The rules will be defined in order, and will only match if all criteria is true 
 - `user` and `password`: username and password for basic auth matching.
 - `query_params`: Key-Value definitions of the query parameters to match. It can use [gorilla/mux](https://pkg.go.dev/github.com/gorilla/mux#Route.Queries) parameters patterns for the values. Web form params will also be added and compared against this for simplicity.
 - `request_headers`: Key-Value definitions of the headers to match. Any headers outside of this list will be ignored. The matches can be defined [as regular expressions](https://pkg.go.dev/github.com/gorilla/mux#Route.HeadersRegexp).
-- `request_body`: a string defining the expected body to match for the request.
+- `request_body`: a string defining the expected body to match for the request. If the string is quoted with slashes, the leading and trailing slash are stripped and the resulting string is interpreted as a regular expression.
 - `responses`: a list of zero or more responses to return on matches. If more than one are set, they will be returned in rolling sequence.
 - `status_code`: the status code to return.
 - `headers`: Key-Value list of the headers to return with the response. The values will be evaluated as [Go templates](https://golang.org/pkg/text/template/).


### PR DESCRIPTION
The allows use of regular expressions in request body matching. This is important when the client sends dynamic request bodies as is the case with filebeat.

There is potential for this to be a breaking change with low probability since the match quote character is in band and no character escaping is used to circumvent confusion in this. However, a request body literally starting and ending with `/` is very unlikely. If it id a wanted request body matching rule, it can be achieved with `//...//` and matching via regexp.

Example usage:

```
rules:
  - path: /api/v1/logs
    methods: ["POST"]
    request_body: /^{"limit":/
    responses:
      - status_code: 200
        headers:
        Link:
          - '<http://{{ hostname }}:{{ env "PORT" }}/api/v1/logs?after=1>; rel="next"'
          - '<https://{{ hostname }}:{{ env "PORT" }}/api/v1/logs?since={{ .request.vars.since }}>; rel="self"'
        body: '{{ file "file.text" }}'
```