### PR TITLE
Fix libdbus missing in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.1]
+
+### Fixed
+
+- Fixed libdbus shared object error in Dockerfile. [#30](https://github.com/elastic/stream/pull/30)
+
 ## [0.6.0]
 
 ### Added
@@ -48,7 +54,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added pcap and log file inputs.
 - Added udp, tcp, and tls outputs.
 
-[Unreleased]: https://github.com/elastic/stream/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/elastic/stream/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/elastic/stream/releases/tag/v0.6.1
 [0.6.0]: https://github.com/elastic/stream/releases/tag/v0.6.0
 [0.5.0]: https://github.com/elastic/stream/releases/tag/v0.5.0
 [0.4.0]: https://github.com/elastic/stream/releases/tag/v0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM debian:stable-slim
 
 COPY --chown=0:0 --from=builder /usr/lib/x86_64-linux-gnu/libpcap.so.0.8 /usr/lib/x86_64-linux-gnu/libpcap.so.0.8
 COPY --chown=0:0 --from=builder /usr/lib/x86_64-linux-gnu/libpcap.so.1.10.0 /usr/lib/x86_64-linux-gnu/libpcap.so.1.10.0
+COPY --chown=0:0 --from=builder /lib/x86_64-linux-gnu/libdbus-1.so.3 /lib/x86_64-linux-gnu/libdbus-1.so.3
 COPY --chown=0:0 --from=builder /app/stream /stream
 
 ENTRYPOINT ["/stream"]


### PR DESCRIPTION
Fixes the error `/stream: error while loading shared libraries: libdbus-1.so.3: cannot open shared object file: No such file or directory` in the Dockerfile