### PR TITLE
Move implicit message framing into TCP/TLS outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Only message sent via TCP and TLS are framed using newlines. UDP messages will
+no longer contain a trailing newline. [#31](https://github.com/elastic/stream/pull/31)
+
 ## [0.6.1]
 
 ### Fixed

--- a/command/log.go
+++ b/command/log.go
@@ -79,7 +79,7 @@ func (r *logRunner) sendLog(path string, out output.Output) error {
 		}
 
 		logger.Debugw("Sending log line.", "line_number", totalLines+1)
-		n, err := out.Write(append(s.Bytes(), '\n'))
+		n, err := out.Write(s.Bytes())
 		if err != nil {
 			return err
 		}

--- a/pkg/output/tcp/tcp.go
+++ b/pkg/output/tcp/tcp.go
@@ -49,5 +49,5 @@ func (o *Output) Close() error {
 }
 
 func (o *Output) Write(b []byte) (int, error) {
-	return o.conn.Write(b)
+	return o.conn.Write(append(b, '\n'))
 }

--- a/pkg/output/tls/tls.go
+++ b/pkg/output/tls/tls.go
@@ -51,5 +51,5 @@ func (o *Output) Close() error {
 }
 
 func (o *Output) Write(b []byte) (int, error) {
-	return o.conn.Write(b)
+	return o.conn.Write(append(b, '\n'))
 }


### PR DESCRIPTION
A newline was appended to the end of all messages, but this newline is only required to properly frame messages
sent over TCP and TLS. So this moves the addition of a newline to the TCP and TLS outputs.

This prevents UDP messages from having a '\n' on them.