### PR TITLE
bump golang version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
     DOCKER_IMG = "${env.DOCKER_REGISTRY}/observability/stream"
     DOCKER_IMG_PR = "${env.DOCKER_REGISTRY}/observability-ci/stream"
     PIPELINE_LOG_LEVEL = 'INFO'
-    GO_VERSION = '1.19.1'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Given the Golang release version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update go version ${GO_RELEASE_VERSION}"
+echo "${GO_RELEASE_VERSION}" > .go-version
+git add .go-version
+
+find . -maxdepth 3 -name Dockerfile -print0 |
+    while IFS= read -r -d '' line; do
+        ${SED} -E -e "s#(FROM golang):[0-9]+\.[0-9]+\.[0-9]+#\1:${GO_RELEASE_VERSION}#g" "$line"
+        git add "${line}"
+    done
+
+GO_MAJOR_VERSION=$(echo ${GO_RELEASE_VERSION} | cut -f1 -d.)
+GO_MINOR_VERSION=$(echo ${GO_RELEASE_VERSION} | cut -f2 -d.)
+${SED} -E -e "s#(go) [0-9]+\.[0-9]+#\1 ${GO_MAJOR_VERSION}\.${GO_MINOR_VERSION}#g" go.mod
+git add go.mod
+
+git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"


### PR DESCRIPTION
### What

Script to bump the Golang version, so this project can be enrolled to the automated auto-bump.
Remove the GO_VERSION env variable in the Pipeline since it's created on the fly by reading the `.go-version` file

### Why

Avoid manual tasks for autobump similarly done in https://github.com/elastic/stream/pull/40/files

### Test

Given `.ci/bump-go-release-version.sh 1.19.2`
Then it produces

```diff
diff --git a/.go-version b/.go-version
index 66e2ae6..836ae4e 100644
--- a/.go-version
+++ b/.go-version
@@ -1 +1 @@
-1.19.1
+1.19.2
diff --git a/Dockerfile b/Dockerfile
index 32e8fee..621859c 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1 as builder
+FROM golang:1.19.2 as builder
 
 RUN apt-get update \
        && apt-get dist-upgrade -y \
diff --git a/go.mod b/go.mod
index becc766..4479731 100644
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/stream
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/pubsub v1.25.1
```