### PR TITLE
[automation] Update go release version 1.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/stream
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/pubsub v1.25.1


### PR DESCRIPTION
### What 

Bump go release version with the latest release. 

### Further details 

See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.19.1+label%3ACherryPickApproved) for 1.19.1

 


_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_