### PR TITLE
Adding support for content type to GCS output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [0.10.0]
+
+### Added
+
+- Added content type support to GCS output: [#51](https://github.com/elastic/stream/pull/51)
+
 ## [0.9.1]
 
 ### Changed

--- a/command/root.go
+++ b/command/root.go
@@ -91,7 +91,7 @@ func ExecuteContext(ctx context.Context) error {
 	// GCS output flags.
 	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.Bucket, "gcs-bucket", "testbucket", "GCS Bucket name")
 	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.Object, "gcs-object", "testobject", "GCS Object name")
-	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.Object, "gcs-content-type", "application/json", "The Content type of the object to be uploaded to GCS.")
+	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.ObjectContentType, "gcs-content-type", "application/json", "The Content type of the object to be uploaded to GCS.")
 	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.ProjectID, "gcs-projectid", "testproject", "GCS Project name")
 
 	// Lumberjack output flags.

--- a/command/root.go
+++ b/command/root.go
@@ -91,6 +91,7 @@ func ExecuteContext(ctx context.Context) error {
 	// GCS output flags.
 	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.Bucket, "gcs-bucket", "testbucket", "GCS Bucket name")
 	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.Object, "gcs-object", "testobject", "GCS Object name")
+	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.Object, "gcs-content-type", "application/json", "The Content type of the object to be uploaded to GCS.")
 	rootCmd.PersistentFlags().StringVar(&opts.GcsOptions.ProjectID, "gcs-projectid", "testproject", "GCS Project name")
 
 	// Lumberjack output flags.

--- a/pkg/output/gcs/gcs.go
+++ b/pkg/output/gcs/gcs.go
@@ -33,6 +33,8 @@ func New(opts *output.Options) (output.Output, error) {
 	}
 	obj := gcsClient.Bucket(opts.GcsOptions.Bucket).Object(opts.GcsOptions.Object)
 	writer := obj.NewWriter(ctx)
+	// System tests are failing because a default content type is not set automatically, so we set it here instead.
+	writer.ObjectAttrs.ContentType = opts.GcsOptions.ObjectContentType
 
 	return &Output{opts: opts, client: gcsClient, cancelFunc: cancel, writer: writer}, nil
 }

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -53,7 +53,8 @@ type LumberjackOptions struct {
 }
 
 type GcsOptions struct {
-	ProjectID string // Project ID, needs to be unique with multiple buckets of the same name.
-	Bucket    string // Bucket name. Will create it if do not exist.
-	Object    string // Name of the object created inside the related Bucket.
+	ProjectID         string // Project ID, needs to be unique with multiple buckets of the same name.
+	ObjectContentType string // The content-type set for the object that is created in the bucket, defaults to application/json
+	Bucket            string // Bucket name. Will create it if do not exist.
+	Object            string // Name of the object created inside the related Bucket.
 }


### PR DESCRIPTION
Content type headers are not set for objects automatically when running against local system tests (like emulators), needs a way to set it correctly.

Added it as a configurable option so we can test multiple content types.