### PR TITLE
pkg/httpjson: add minify_json template helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `minify_json` template helper function for minifying static JSON: [#x](https://github.com/elastic/stream/pull/x)
+
 ### Changed
 
 ### Fixed

--- a/pkg/httpserver/config.go
+++ b/pkg/httpserver/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"text/template"
 
 	ucfg "github.com/elastic/go-ucfg"
@@ -102,6 +103,9 @@ func file(path string) (string, error) {
 }
 
 func minify(body string) (string, error) {
-	b, err := json.Marshal(json.RawMessage(body))
-	return string(b), err
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(json.RawMessage(body))
+	return strings.TrimSpace(buf.String()), err
 }

--- a/pkg/httpserver/config.go
+++ b/pkg/httpserver/config.go
@@ -5,6 +5,7 @@
 package httpserver
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"text/template"
@@ -45,10 +46,11 @@ func (t *tpl) Unpack(in string) error {
 	parsed, err := template.New("").
 		Option("missingkey=zero").
 		Funcs(template.FuncMap{
-			"env":      env,
-			"hostname": hostname,
-			"sum":      sum,
-			"file":     file,
+			"env":         env,
+			"hostname":    hostname,
+			"sum":         sum,
+			"file":        file,
+			"minify_json": minify,
 		}).
 		Parse(in)
 	if err != nil {
@@ -97,4 +99,9 @@ func file(path string) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+func minify(body string) (string, error) {
+	b, err := json.Marshal(json.RawMessage(body))
+	return string(b), err
 }

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -63,7 +63,7 @@ func TestHTTPServer(t *testing.T) {
           {{ minify_json ` + "`" + `
           {
           	"key1": "value1",
-          	"key2": "value2"
+          	"key2": "<value2>"
           }
           ` + "`" + `}}
 `
@@ -162,7 +162,7 @@ func TestHTTPServer(t *testing.T) {
 		require.NoError(t, err)
 		resp.Body.Close()
 
-		assert.Equal(t, `{"key1":"value1","key2":"value2"}`, string(body))
+		assert.Equal(t, `{"key1":"value1","key2":"<value2>"}`, string(body))
 	})
 }
 

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -44,6 +44,7 @@ func TestHTTPServer(t *testing.T) {
         status_code: 200
         body: |-
           {"next": "http://{{ hostname }}/page/{{ sum (.req_num) 1 }}"}
+
     - path: "/page/{pagenum:[0-9]}"
       methods: ["POST"]
 
@@ -52,6 +53,19 @@ func TestHTTPServer(t *testing.T) {
         body: "{{ .request.vars.pagenum }}"
         headers:
           content-type: ["text/plain"]
+
+    - path: "/static/minify"
+      methods: ["GET"]
+
+      responses:
+      - status_code: 200
+        body: |-
+          {{ minify_json ` + "`" + `
+          {
+          	"key1": "value1",
+          	"key2": "value2"
+          }
+          ` + "`" + `}}
 `
 
 	f, err := ioutil.TempFile("", "test")
@@ -135,6 +149,20 @@ func TestHTTPServer(t *testing.T) {
 		resp.Body.Close()
 
 		assert.Equal(t, []byte{}, body)
+	})
+
+	t.Run("minify static JSON", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://"+addr+"/static/minify", nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		assert.Equal(t, `{"key1":"value1","key2":"value2"}`, string(body))
 	})
 }
 


### PR DESCRIPTION
This helper allows nicely formatted JSON to be sent the the client as single-line JSON text.

```
rules:
- path: "/static/minify"
  methods: ["GET"]
    
  responses:
  - status_code: 200
    body: |-
      {{ minify_json `
      {
        "key1": "value1",
        "key2": "value2"
      }
      `}}
```

will respond to requests to /static/minify with `{"key1":"value1","key2":"value2"}`.