### PR TITLE
.golangci.yml - Removed deprecated linters and unused depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - stylecheck
     - typecheck
     - unused
-    - depguard
     - errorlint
     - gofumpt
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,24 +7,20 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unused
-    - varcheck
     - depguard
     - errorlint
     - gofumpt
     - goimports
     - godox
     - goheader
-    - ifshort
     - misspell
     - prealloc
     - unconvert


### PR DESCRIPTION
Remove deprecated linters:

    WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.
    WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
    WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
    WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.

Remove depguard. The linter was not configured with any rules so it blocks all imports.
