### PR TITLE
docker-build: create multi-arch image amd64,arm64

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,10 @@ steps:
   - label: "Publish PR Docker Image"
     key: "publish-pr-img"
     if: build.env("BUILDKITE_PULL_REQUEST") != "false"
-    command: ".buildkite/scripts/docker-build.sh ${DOCKER_IMG_PR}"
+    command:
+      - "sudo apt-get update"
+      - "sudo apt-get install -y qemu-user-static binfmt-support"
+      - ".buildkite/scripts/docker-build.sh ${DOCKER_IMG_PR}"
     notify:
       - github_commit_status:
           context: "Publish PR Image"
@@ -66,7 +69,10 @@ steps:
   - label: "Publish Docker Image"
     key: "publish-nonpr-img"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false"
-    command: ".buildkite/scripts/docker-build.sh ${DOCKER_IMG}"
+    command:
+      - "sudo apt-get update"
+      - "sudo apt-get install -y qemu-user-static binfmt-support"
+      - ".buildkite/scripts/docker-build.sh ${DOCKER_IMG}"
     notify:
       - github_commit_status:
           context: "Publish non-PR Image"

--- a/.buildkite/scripts/docker-build.sh
+++ b/.buildkite/scripts/docker-build.sh
@@ -11,12 +11,5 @@ base_commit=$(get_base_commit)
 commit_tag=$(docker_commit_tag "${docker_img}" "${base_commit}")
 branch_tag=$(docker_branch_tag "${docker_img}" "${BUILDKITE_BRANCH}")
 
-echo ":: Building image - ${commit_tag} ::"
-build_image "${commit_tag}" "${base_commit}"
-
-echo ":: Pushing image - ${commit_tag} ::"
-retry 3 docker push "${commit_tag}"
-
-echo ":: Re-tagging image from ${commit_tag} to ${branch_tag} ::"
-retry 3 docker tag  "${commit_tag}" "${branch_tag}"
-retry 3 docker push "${branch_tag}"
+echo ":: Building and pushing image - ${commit_tag} ::"
+build_and_push_image "${base_commit}" -t "${commit_tag}" -t "${branch_tag}"

--- a/.buildkite/scripts/image-util.sh
+++ b/.buildkite/scripts/image-util.sh
@@ -31,15 +31,20 @@ docker_branch_tag() {
   echo "${image}:${branch_tag}"
 }
 
-build_image() {
-  local commit_tag=$1
-  local base_commit=$2
+build_and_push_image() {
+  local base_commit=$1
+  shift
+  local extra_args=("$@")
 
-  docker build \
-    -t "${commit_tag}" \
+  docker buildx create --platform linux/amd64,linux/arm64 --use
+  docker buildx build \
+    --progress=plain \
+    --platform linux/amd64,linux/arm64 \
+    --push \
     --label BRANCH_NAME="${BUILDKITE_BRANCH}" \
     --label GIT_SHA="${base_commit}" \
     --label GO_VERSION="${GOLANG_VERSION}" \
     --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
+    ${extra_args[@]} \
     .
 }

--- a/.buildkite/scripts/image-util.sh
+++ b/.buildkite/scripts/image-util.sh
@@ -28,6 +28,13 @@ docker_branch_tag() {
     branch_tag="${branch}"
   fi
 
+  # Sanitize the branch name using parameter expansion.
+  # The tag must be valid ASCII and can contain lowercase and uppercase letters,
+  # digits, underscores, periods, and hyphens. It can't start with a period or
+  # hyphen and must be no longer than 128 characters.
+  branch_tag=${branch_tag//[^a-zA-Z0-9]/_}
+  branch_tag=${branch_tag:0:128}
+
   echo "${image}:${branch_tag}"
 }
 

--- a/.buildkite/scripts/retag.sh
+++ b/.buildkite/scripts/retag.sh
@@ -12,5 +12,6 @@ old_tag=$(docker_commit_tag "${docker_img}" "${base_commit}")
 new_tag="${BUILDKITE_TAG}"
 
 echo ":: Re-tagging image from ${old_tag} to ${new_tag} ::"
+retry 3 docker pull "${old_tag}"
 retry 3 docker tag  "${old_tag}" "${new_tag}"
 retry 3 docker push "${new_tag}"


### PR DESCRIPTION
Use docker buildx to produce a multi-arch image that can run natively on linux/amd64 and linux/arm64.
    
Sanitize the branch name because it is used as a docker tag. Special characters need to be removed.

Closes #77

References
- https://docs.docker.com/reference/cli/docker/image/tag/
- https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html