### PR TITLE
docker image: reduce image size by using alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM golang:1.22.1 as builder
+FROM golang:1.22.1-alpine3.19 as builder
 
-RUN apt-get update \
-       && apt-get dist-upgrade -y \
-       && apt-get install -y libpcap-dev \
-       && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache musl-dev gcc libpcap libpcap-dev
 
 ADD . /app
 
@@ -14,12 +11,9 @@ RUN go mod download
 RUN go build
 
 # ------------------------------------------------------------------------------
-FROM debian:stable-slim
+FROM alpine:3.19
 
-RUN apt-get update \
-       && apt-get dist-upgrade -y \
-       && apt-get install -y libpcap0.8 \
-       && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache libpcap
 
 COPY --chown=0:0 --from=builder /app/stream /stream
 


### PR DESCRIPTION
Switch to an alpine 3.19 base image for the docker image. The resulting image is 42MB compared to 129MB before. This will save transfer costs on CI and speed up downloads. The stream binary is linked with musl libc.

```
# ldd stream
        /lib/ld-musl-aarch64.so.1 (0xffffac8cd000)
        libpcap.so.1 => /usr/lib/libpcap.so.1 (0xffffac87c000)
        libc.musl-aarch64.so.1 => /lib/ld-musl-aarch64.so.1 (0xffffac8cd000)
```