### PR TITLE
fix: utilise docker buildx imagetools to support re-tagging multi-platform images

### DIFF
--- a/.buildkite/scripts/retag.sh
+++ b/.buildkite/scripts/retag.sh
@@ -12,6 +12,4 @@ old_tag=$(docker_commit_tag "${docker_img}" "${base_commit}")
 new_tag="${BUILDKITE_TAG}"
 
 echo ":: Re-tagging image from ${old_tag} to ${new_tag} ::"
-retry 3 docker pull "${old_tag}"
-retry 3 docker tag  "${old_tag}" "${new_tag}"
-retry 3 docker push "${new_tag}"
+retry 3 docker buildx imagetools create -t "${new_tag}" "${old_tag}"


### PR DESCRIPTION
this PR utilises `docker buildx imagetools create -t "${new_tag}" "${old_tag}"` to support re-tagging multi-platform images. With the flow of `docker pull -> tag -> push` a single platform image will be produced matching the platform of the docker daemon host 