### PR TITLE
fix[pcap]: check for nil packet and transport layer

### DIFF
--- a/internal/command/pcap.go
+++ b/internal/command/pcap.go
@@ -71,7 +71,18 @@ func (r *pcapRunner) sendPCAP(path string, out output.Output) error {
 			break
 		}
 
-		payloadData := packet.TransportLayer().LayerPayload()
+		if packet == nil {
+			logger.Warnw("Skipping nil packet")
+			continue
+		}
+
+		tl := packet.TransportLayer()
+		if tl == nil {
+			logger.Warnw("Skipping packet with no transport layer")
+			continue
+		}
+
+		payloadData := tl.LayerPayload()
 
 		// TODO: Rate-limit for UDP.
 		n, err := out.Write(payloadData)


### PR DESCRIPTION
While streaming a customer supplied pcap for the needs of https://github.com/elastic/sdh-beats/issues/4544 I stumbled upon a nil pointer access panic. This PR fixes that case  