### PR TITLE
.github/workflows/release.yml - Fix YAML string format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
           fetch-depth: 0 # Need full history.
 
       - name: release notes
-        run: >-
-          go run github.com/hashicorp/go-changelog/cmd/changelog-build@ba40b3a
-          -changelog-template .github/release/changelog.gotmpl
-          -note-template .github/release/release-note.gotmpl
-          -entries-dir ./.changelog
-          -last-release "${{ inputs.last_release }}"
-          -this-release HEAD | tee /tmp/release-notes.txt
+        run: |
+          go run github.com/hashicorp/go-changelog/cmd/changelog-build@ba40b3a \
+            -changelog-template .github/release/changelog.gotmpl \
+            -note-template .github/release/release-note.gotmpl \
+            -entries-dir ./.changelog \
+            -last-release "${{ inputs.last_release }}" \
+            -this-release HEAD | tee /tmp/release-notes.txt
 
           cat << EOF >> /tmp/release-notes.txt
           DOWNLOAD:
@@ -44,8 +44,8 @@ jobs:
       - name: draft GH release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create "${{ inputs.version }}"
-          --draft
-          --notes-file /tmp/release-notes.txt
+        run: |
+          gh release create "${{ inputs.version }}" \
+          --draft \
+          --notes-file /tmp/release-notes.txt \
           --title "${{ inputs.version }}"


### PR DESCRIPTION
The here-document failed because the of the string format. I changed them all to use `|` for consistency.


------

https://github.com/elastic/stream/actions/runs/8542044096/job/23402795336
```
/home/runner/work/_temp/e494e4f0-bdd8-410e-a96f-50c2ffe67a3e.sh: line 3: warning: here-document at line 2 delimited by end-of-file (wanted `EOF')
cat: 'DOWNLOAD:': No such file or directory
```