### PR TITLE
Close TCP, TLS connections gracefully to avoid data loss

### DIFF
--- a/.changelog/123.txt
+++ b/.changelog/123.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+TCP, TLS outputs: Close connections gracefully to avoid data loss.
+```

--- a/internal/output/tcp/tcp.go
+++ b/internal/output/tcp/tcp.go
@@ -6,6 +6,7 @@ package tcp
 
 import (
 	"context"
+	"io"
 	"net"
 	"time"
 
@@ -18,7 +19,7 @@ func init() {
 
 type Output struct {
 	opts *output.Options
-	conn net.Conn
+	conn *net.TCPConn
 }
 
 func New(opts *output.Options) (output.Output, error) {
@@ -33,7 +34,7 @@ func (o *Output) DialContext(ctx context.Context) error {
 		return err
 	}
 
-	o.conn = conn
+	o.conn = conn.(*net.TCPConn)
 	return nil
 }
 
@@ -42,10 +43,27 @@ func (o *Output) Conn() net.Conn {
 }
 
 func (o *Output) Close() error {
-	if o.conn == nil {
-		return nil
+	if o.conn != nil {
+		o.conn.CloseWrite()
+
+		// drain to facilitate graceful close on the other side
+		deadline := time.Now().Add(5 * time.Second)
+		if err := o.conn.SetReadDeadline(deadline); err != nil {
+			return err
+		}
+		buffer := make([]byte, 1024)
+		for {
+			_, err := o.conn.Read(buffer)
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+		}
+
+		return o.conn.Close()
 	}
-	return o.conn.Close()
+	return nil
 }
 
 func (o *Output) Write(b []byte) (int, error) {


### PR DESCRIPTION
## Proposed commit message

```
Close TCP, TLS connections gracefully to avoid data loss (#)

TCP connections, including TLS connections, acknowledge received data.

Although a simple `net.Conn.Close()` will put all previously written
data on the network, the receiving server may disregard data that it
can't successfully acknowledge.

Graceful acknowledgement and closure can be facilitated by the client
closing writes first, and reading any available data before fully
closing the connection.
```

## Checklist

- [ ] Run the release workflow in GitHub actions (after merge)

## Discussion

This bug was discovered due to flaky tests that use `stream` (issues listed below).

For a more detailed discussion of this topic please read the blog post
[The ultimate SO_LINGER page, or: why is my tcp not reliable](https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable).

I tested this manually. Failures of the old version can be demonstrated as follows. Here I use data from `integrations` that is know to trigger the issue.

### TLS

In one terminal run this server loop:
```
while true; do
  echo Running the server...
  echo
  openssl s_server -accept 4433 -naccept 1 \
    -cert ~/.elastic-package/profiles/default/certs/elastic-agent/cert.pem \
    -key ~/.elastic-package/profiles/default/certs/elastic-agent/key.pem \
    2>&1 | pv -L 100k | tee output.log
  echo
  if grep -q "ERROR" output.log; then
    echo "Error detected. Stopping."
    break
  fi
done
```

In another, repeatedly run this client:
```
go run main.go log --delay=1s --addr localhost:4433 -p=tls --insecure ../integrations/packages/cyberarkpas/_dev/deploy/docker/sample_logs/audit/*.log
```

It should fail within a few runs. It fails more readily if the client is run soon after the server starts. If necessary, lowering the rate limit enforced by `pv` may help trigger a failure.

### TCP

This uses GNU Netcat (BSD Netcat may differ). Having the server write some data seems to be necessary for the error to happen.

The server:
```
input_lines=$(cat ../integrations/packages/cyberarkpas/_dev/deploy/docker/sample_logs/audit/*.log | wc -l)
while true; do
  echo Running the server...
  echo
  echo hi | nc -l -p 8888 | pv -L 100k | tee output.log
  echo
  output_lines=$(cat output.log | wc -l)
  if [ "$output_lines" != "$input_lines" ]; then
    echo "Error detected: $output_lines lines received != $input_lines lines sent. Stopping."
    break
  fi
done
```

The client:
```
go run main.go log --delay=1s --addr localhost:8888 -p=tcp ../integrations/packages/cyberarkpas/_dev/deploy/docker/sample_logs/audit/*.log
```

## Related issues

- Closes #120
- Closes https://github.com/elastic/integrations/issues/11224
- Closes https://github.com/elastic/integrations/issues/10620
- Related https://github.com/elastic/integrations/issues/11075