### PR TITLE
fix(updatecli): put full go version into go.mod

### DIFF
--- a/.buildkite/bump-golang.yml
+++ b/.buildkite/bump-golang.yml
@@ -48,7 +48,7 @@ sources:
     kind: shell
     transformers:
       - findsubmatch:
-          pattern: '^(\d+.\d+)(.\d+)?'
+          pattern: '^(\d+.\d+.\d+)'
           captureindex: 1
     spec:
       command: echo {{ source "latestGoVersion" }}
@@ -71,7 +71,7 @@ conditions:
 
 targets:
   update-go-version:
-    name: "Update .go-version"
+    name: Update .go-version with {{ source "latestGoVersion" }}
     sourceid: latestGoVersion
     scmid: githubConfig
     kind: file
@@ -80,7 +80,7 @@ targets:
       file: .go-version
       matchpattern: '\d+.\d+.\d+'
   update-dockerfiles:
-    name: "Update from dockerfiles"
+    name: Update Dockerfile golang image
     sourceid: latestGoVersion
     scmid: githubConfig
     kind: file
@@ -97,4 +97,4 @@ targets:
     spec:
       content: 'go {{ source "gomod" }}'
       file: go.mod
-      matchpattern: 'go \d+.\d+'
+      matchpattern: 'go \d+\.\d+.*'

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * 6'
+  pull_request:
+    paths:
+      - .buildkite/bump-golang.yml
+      - .github/workflows/bump-golang.yml
 
 permissions:
   pull-requests: write
@@ -14,7 +18,6 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
 
       - name: Setup Git
@@ -23,7 +26,14 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@f11c0cb3aca7a018d6000dc86a57eb3442277219 # v2.81.0
 
-      - name: Run Updatecli
+      - name: Run Updatecli diff
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: updatecli diff --config ./.buildkite/bump-golang.yml
+
+      - name: Run Updatecli apply
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: updatecli apply --config ./.buildkite/bump-golang.yml


### PR DESCRIPTION
Put a complete (major.minor.patch) version into the go directive of the go.mod file.

It used to write `go major.minor` under the assumption that this was the first valid
minor release, and that the module would generally be compatible with the entire
series of Go patch release under that minor. While the latter is still true, we do need
to write a valid Go version into the directive.