### PR TITLE
fix(Dockerfile): correct casing for FROM ... AS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine3.21 as builder
+FROM golang:1.24.4-alpine3.21 AS builder
 
 RUN apk add --no-cache musl-dev gcc libpcap libpcap-dev
 


### PR DESCRIPTION
Docker was emitting a warning about `FROM ... as` being mixed case. 
This changes it to `FROM ... AS` to remove the warning.