### PR TITLE
fix: ensure env vars are applied to subcommands args

### DIFF
--- a/.changelog/162.txt
+++ b/.changelog/162.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Added support for configuring command-line flags of sub-commands (such as http-server) using environment variables. For example, you can set STREAM_CONFIG=config.yml to specify a configuration file.
+```

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -135,6 +135,9 @@ func ExecuteContext(ctx context.Context) error {
 
 	// Automatically set flags based on environment variables.
 	rootCmd.PersistentFlags().VisitAll(setFlagFromEnv)
+	for _, cmd := range rootCmd.Commands() {
+		cmd.PersistentFlags().VisitAll(setFlagFromEnv)
+	}
 
 	return rootCmd.ExecuteContext(ctx)
 }


### PR DESCRIPTION
Added support for configuring command-line flags of sub-commands (such as http-server) using environment variables. For example, you can set `STREAM_CONFIG=config.yml` to specify a configuration file.