### PR TITLE
http mock server: Added glob template helper function

### DIFF
--- a/.changelog/165.txt
+++ b/.changelog/165.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+http mock server: Added glob template helper function for iterating over multiple files.
+```

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ When using [Go templates](https://golang.org/pkg/text/template/) as part of the 
 - `env KEY`: function that returns the KEY from environment.
 - `sum A B`: function that returns the sum of numbers A and B (only for integers).
 - `file PATH`: function that returns the contents of the file at PATH.
+- `glob PATTERN`: function that returns the names of all files matching PATTERN.
 - `.req_num`: variable containing the current request number, auto incremented after every request for the rule.
 - `.request.vars`: map containing the variables received in the request (both query and form).
 - `.request.url`: the url object. Can be used as per [the Go URL documentation.](https://golang.org/pkg/net/url/#URL)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When using [Go templates](https://golang.org/pkg/text/template/) as part of the 
 - `env KEY`: function that returns the KEY from environment.
 - `sum A B`: function that returns the sum of numbers A and B (only for integers).
 - `file PATH`: function that returns the contents of the file at PATH.
-- `glob PATTERN`: function that returns the names of all files matching PATTERN.
+- `glob PATTERN`: function that returns the names of all files matching glob PATTERN (see [filepath.Match](https://pkg.go.dev/path/filepath#Match) for syntax).
 - `.req_num`: variable containing the current request number, auto incremented after every request for the rule.
 - `.request.vars`: map containing the variables received in the request (both query and form).
 - `.request.url`: the url object. Can be used as per [the Go URL documentation.](https://golang.org/pkg/net/url/#URL)

--- a/internal/httpserver/config.go
+++ b/internal/httpserver/config.go
@@ -52,7 +52,7 @@ func (t *tpl) Unpack(in string) error {
 			"hostname":    hostname,
 			"sum":         sum,
 			"file":        file,
-			"glob":        glob,
+			"glob":        filepath.Glob,
 			"minify_json": minify,
 		}).
 		Parse(in)
@@ -102,10 +102,6 @@ func file(path string) (string, error) {
 		return "", err
 	}
 	return string(b), nil
-}
-
-func glob(pattern string) ([]string, error) {
-	return filepath.Glob(pattern)
 }
 
 func minify(body string) (string, error) {

--- a/internal/httpserver/config.go
+++ b/internal/httpserver/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -51,6 +52,7 @@ func (t *tpl) Unpack(in string) error {
 			"hostname":    hostname,
 			"sum":         sum,
 			"file":        file,
+			"glob":        glob,
 			"minify_json": minify,
 		}).
 		Parse(in)
@@ -100,6 +102,10 @@ func file(path string) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+func glob(pattern string) ([]string, error) {
+	return filepath.Glob(pattern)
 }
 
 func minify(body string) (string, error) {


### PR DESCRIPTION
With `glob` + `file` helpers, we can read from multiple files matching a pattern.

Closes https://github.com/elastic/stream/issues/161