### PR TITLE
Expose inbound request host to http-server templates

### DIFF
--- a/.changelog/207.txt
+++ b/.changelog/207.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+http-server: Expose `.request.host` in response templates for same-origin absolute URL generation in Link headers and pagination responses.
+```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ on certain routes. The config should be defined in a yaml file of the following 
         body: "{{ .request.vars.pagenum }}"
         headers:
           content-type: ["text/plain"]
+    - path: "/orgs/test/audit-log"
+      methods: ["GET"]
+
+      responses:
+      - status_code: 200
+        headers:
+          Link:
+            - '<http://{{ .request.host }}/orgs/test/audit-log?after=abcd>; rel="next"'
+        body: |-
+          []
 ```
 
 The rules will be defined in order, and will only match if all criteria is true for a request. This means that you need to define the more restrictive rules on top.
@@ -90,6 +100,7 @@ When using [Go templates](https://golang.org/pkg/text/template/) as part of the 
 - `glob PATTERN`: function that returns the names of all files matching glob PATTERN (see [filepath.Match](https://pkg.go.dev/path/filepath#Match) for syntax).
 - `now [OFFSET]`: function that returns the current UTC time as a Go `time.Time` value. An optional Go duration string offsets the result (e.g. `{{ now "-720h" }}` for 30 days ago). The returned value exposes all `time.Time` methods, so it can be formatted in templates: `{{ (now).Format "2006-01-02T15:04:05Z07:00" }}`.
 - `.req_num`: variable containing the current request number, auto incremented after every request for the rule.
+- `.request.host`: the inbound request host from [http.Request.Host](https://pkg.go.dev/net/http#Request.Host). Use this to build same-origin absolute URLs in response templates, such as RFC 5988 `Link` headers, from the host the client used for the request.
 - `.request.vars`: map containing the variables received in the request (both query and form).
 - `.request.url`: the url object. Can be used as per [the Go URL documentation.](https://golang.org/pkg/net/url/#URL)
 - `.request.headers` the headers object. Can be used as per [the Go http.Header documentation.](https://golang.org/pkg/net/http/#Header)

--- a/internal/httpserver/httpserver.go
+++ b/internal/httpserver/httpserver.go
@@ -193,6 +193,7 @@ func newHandlerFromConfig(config *config, notFoundHandler http.HandlerFunc, logg
 			data := map[string]interface{}{
 				"req_num": count,
 				"request": map[string]interface{}{
+					"host":    r.Host,
 					"vars":    mux.Vars(r),
 					"url":     r.URL,
 					"headers": r.Header,

--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,6 +85,17 @@ func TestHTTPServer(t *testing.T) {
       - status_code: 200
         body: |-
           {"ts": "{{ (now "-720h").Format "2006-01-02T15:04:05Z07:00" }}"}
+
+    - path: "/orgs/test/audit-log"
+      methods: ["GET"]
+
+      responses:
+      - status_code: 200
+        headers:
+          Link:
+            - '<http://{{ .request.host }}/orgs/test/audit-log?after=abcd>; rel="next"'
+        body: |-
+          []
 `
 
 	f, err := ioutil.TempFile("", "test")
@@ -213,6 +225,39 @@ func TestHTTPServer(t *testing.T) {
 		}
 		if got.Before(before.Add(-time.Second)) || got.After(time.Now().UTC().Add(time.Second)) {
 			t.Errorf("now() = %s; want between %s and now", got, before)
+		}
+	})
+
+	t.Run("request host is available in response templates", func(t *testing.T) {
+		host := "svc-github" + addr[strings.LastIndex(addr, ":"):]
+		req, err := http.NewRequest("GET", "http://"+addr+"/orgs/test/audit-log", nil)
+		if err != nil {
+			t.Fatalf("NewRequest error: %v", err)
+		}
+		req.Host = host
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do error: %v", err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("StatusCode = %d; want 200", resp.StatusCode)
+		}
+
+		wantLink := fmt.Sprintf(`<http://%s/orgs/test/audit-log?after=abcd>; rel="next"`, host)
+		if got := resp.Header.Get("Link"); got != wantLink {
+			t.Fatalf("Link header = %q; want %q", got, wantLink)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll error: %v", err)
+		}
+		resp.Body.Close()
+
+		if got := string(body); got != "[]" {
+			t.Fatalf("body = %q; want %q", got, "[]")
 		}
 	})
 


### PR DESCRIPTION
Mock APIs need same-origin absolute URLs in Link headers and pagination responses, but {{ hostname }} returns the container OS hostname rather than the host the client used. Add .request.host from http.Request.Host so fixtures can build URLs from the actual inbound request.

Closes #206