### PR TITLE
Remove libpcap dependency and add Windows support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,8 +12,6 @@ steps:
   - label: ":golangci-lint: Lint"
     key: "lint"
     command:
-      - "sudo apt-get update"
-      - "sudo apt-get install -y libpcap-dev"
       - ".buildkite/scripts/lint.sh"
     notify:
       - github_commit_status:
@@ -25,8 +23,6 @@ steps:
   - label: ":go: Build-${GOLANG_VERSION}"
     key: "build"
     command:
-      - "sudo apt-get update"
-      - "sudo apt-get install -y libpcap-dev"
       - ".buildkite/scripts/build.sh"
     notify:
       - github_commit_status:
@@ -39,8 +35,6 @@ steps:
   - label: ":go: Test-${GOLANG_VERSION}"
     key: "test"
     command:
-      - "sudo apt-get update"
-      - "sudo apt-get install -y libpcap-dev"
       - ".buildkite/scripts/go-test.sh"
     notify:
       - github_commit_status:

--- a/.changelog/210.txt
+++ b/.changelog/210.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+build: Removed the libpcap dependency by reading capture files with pure Go. stream now builds with CGO_ENABLED=0, so `go install github.com/elastic/stream@latest` works without libpcap or a C compiler.
+```
+
+```release-note:enhancement
+Added Windows support. stream previously failed to compile for Windows.
+```
+
+```release-note:enhancement
+pcap: Report an error when a capture file cannot be parsed instead of retrying the unreadable record indefinitely.
+```
+
+```release-note:note
+The Docker image is now built FROM scratch rather than from Alpine, because the binary is statically linked and no longer needs libpcap. The image no longer contains a shell or any other userland utilities.
+```

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -1,0 +1,74 @@
+name: cross-build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Verify that stream builds for every platform we expect users to install it
+  # on, without cgo and without any C toolchain or libpcap present. This is what
+  # `go install github.com/elastic/stream@latest` does on a user's machine.
+  build:
+    name: build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+    env:
+      CGO_ENABLED: "0"
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: .go-version
+
+      - name: build
+        run: go build -o /dev/null .
+
+      - name: vet
+        run: go vet ./...
+
+  # Run the tests on real runners so platform specific behavior, such as signal
+  # name lookup, is exercised and not just compiled.
+  test:
+    name: test ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    env:
+      CGO_ENABLED: "0"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: .go-version
+
+      - name: test
+        run: go test ./internal/command/...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
-
       - name: Read .go-version file
         id: goversion
         run: echo "::set-output name=version::$(cat .go-version)"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install libpcap-dev
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
-
       - name: Read .go-version file
         id: goversion
         run: echo "::set-output name=version::$(cat .go-version)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
 FROM golang:1.26.5-alpine3.23 AS builder
 
-RUN apk add --no-cache musl-dev gcc libpcap libpcap-dev
-
 ADD . /app
 
 WORKDIR /app
 
 RUN go mod download
 
-RUN go build
+# stream is pure Go, so build a static binary that depends on neither libc nor
+# libpcap and can run in an image with no userland at all.
+RUN CGO_ENABLED=0 go build
 
 # ------------------------------------------------------------------------------
-FROM alpine:3.23
+FROM scratch
 
-RUN apk add --no-cache libpcap
+# The static binary needs no operating system, but the TLS based outputs need
+# root certificates in order to verify the certificates servers present.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY --chown=0:0 --from=builder /app/stream /stream
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,37 @@ Input data can be read from:
 
 - log file - Newline delimited files are streamed line by line.
 - pcap file - Each packet's transport layer payload is streamed as a packet.
-  Useful for replaying netflow and IPFIX captures.
+  Useful for replaying netflow and IPFIX captures. Both pcap and pcapng files are
+  supported, including gzip compressed ones.
+
+## Installation
+
+Install the latest release with Go:
+
+```bash
+go install github.com/elastic/stream@latest
+```
+
+stream is pure Go, so this works on Linux, macOS, and Windows without a C
+compiler or any system libraries.
+
+Alternatively, use the container image:
+
+```bash
+docker pull docker.elastic.co/observability/stream:main
+```
+
+The `main` tag tracks the main branch. Substitute a release tag, such as
+`v0.23.0`, to pin to a specific version.
+
+The image is built `FROM scratch` and contains only the stream binary and root
+certificates. There is no shell inside it.
+
+### Platform notes
+
+`--start-signal` accepts any signal name on Unix-like systems. On Windows only
+`SIGINT` and `SIGTERM` are recognized, because those are the only signals the Go
+runtime emulates there.
 
 ## HTTP Server mock reference
 

--- a/internal/command/pcap.go
+++ b/internal/command/pcap.go
@@ -5,8 +5,17 @@
 package command
 
 import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/google/gopacket"
-	"github.com/google/gopacket/pcap"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
@@ -55,27 +64,89 @@ func (r *pcapRunner) Run(files []string) error {
 	return nil
 }
 
+// pcapNgMagic is the block type of the Section Header Block that begins every
+// pcapng file. It is palindromic, so it identifies the format regardless of the
+// byte order the file was written in.
+var pcapNgMagic = []byte{0x0a, 0x0d, 0x0d, 0x0a}
+
+// gzipMagic is the two byte header that begins every gzip stream.
+var gzipMagic = []byte{0x1f, 0x8b}
+
+// newPacketReader returns a packet source for the pcap or pcapng data in r,
+// along with the link type of its packets. Gzip compressed captures are
+// decompressed transparently.
+func newPacketReader(r io.Reader) (gopacket.PacketDataSource, layers.LinkType, error) {
+	br := bufio.NewReader(r)
+
+	if magic, err := br.Peek(len(gzipMagic)); err == nil && bytes.Equal(magic, gzipMagic) {
+		gzipReader, err := gzip.NewReader(br)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to open gzip stream: %w", err)
+		}
+		br = bufio.NewReader(gzipReader)
+	}
+
+	magic, err := br.Peek(len(pcapNgMagic))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read capture file header: %w", err)
+	}
+
+	if bytes.Equal(magic, pcapNgMagic) {
+		opts := pcapgo.DefaultNgReaderOptions
+		// The defaults already mirror libpcap: the link type comes from the
+		// first interface and packets from interfaces with a differing link
+		// type are ignored. Skipping unknown section versions is recommended by
+		// the pcapng spec and matches libpcap, which would otherwise leave a
+		// capture containing a newer section unreadable.
+		opts.SkipUnknownVersion = true
+
+		reader, err := pcapgo.NewNgReader(br, opts)
+		if err != nil {
+			return nil, 0, fmt.Errorf("invalid pcapng header: %w", err)
+		}
+		return reader, reader.LinkType(), nil
+	}
+
+	reader, err := pcapgo.NewReader(br)
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid pcap header: %w", err)
+	}
+	return reader, reader.LinkType(), nil
+}
+
 func (r *pcapRunner) sendPCAP(path string, out output.Output) error {
 	logger := r.logger.With("pcap", path)
 
-	f, err := pcap.OpenOffline(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
+	source, linkType, err := newPacketReader(f)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
 	// Process packets in PCAP and get flow records.
 	var totalBytes, totalPackets int
-	packetSource := gopacket.NewPacketSource(f, f.LinkType())
-	for packet := range packetSource.Packets() {
-		if r.cmd.Context().Err() != nil {
-			break
+readPackets:
+	for r.cmd.Context().Err() == nil {
+		data, _, err := source.ReadPacketData()
+		switch {
+		case err == nil:
+		case errors.Is(err, io.EOF):
+			// End of the capture.
+			break readPackets
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			// Tolerate truncated captures and stream what was readable.
+			logger.Warnw("Capture file is truncated, stopping early", "total_packets", totalPackets)
+			break readPackets
+		default:
+			return fmt.Errorf("failed to read packet %d from %s: %w", totalPackets+1, path, err)
 		}
 
-		if packet == nil {
-			logger.Warnw("Skipping nil packet")
-			continue
-		}
+		packet := gopacket.NewPacket(data, linkType, gopacket.Default)
 
 		tl := packet.TransportLayer()
 		if tl == nil {

--- a/internal/command/pcap_test.go
+++ b/internal/command/pcap_test.go
@@ -1,0 +1,333 @@
+// Licensed to Elasticsearch B.V. under one or more agreements.
+// Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+package command
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// helpers
+
+// udpPacket builds an Ethernet/IPv4/UDP frame carrying payload.
+func udpPacket(t *testing.T, payload string) []byte {
+	t.Helper()
+
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		DstMAC:       net.HardwareAddr{0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		SrcIP:    net.IPv4(10, 0, 0, 1),
+		DstIP:    net.IPv4(10, 0, 0, 2),
+		Protocol: layers.IPProtocolUDP,
+	}
+	udp := &layers.UDP{SrcPort: 12345, DstPort: 2055}
+	require.NoError(t, udp.SetNetworkLayerForChecksum(ip))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	require.NoError(t, gopacket.SerializeLayers(buf, opts, eth, ip, udp, gopacket.Payload(payload)))
+	return buf.Bytes()
+}
+
+// writePCAP writes packets to a classic libpcap capture file and returns its path.
+func writePCAP(t *testing.T, packets ...[]byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.pcap")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w := pcapgo.NewWriter(f)
+	require.NoError(t, w.WriteFileHeader(65536, layers.LinkTypeEthernet))
+	for _, p := range packets {
+		require.NoError(t, w.WritePacket(captureInfo(p), p))
+	}
+	return path
+}
+
+// writePCAPNg writes packets to a pcapng capture file and returns its path.
+func writePCAPNg(t *testing.T, packets ...[]byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.pcapng")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w, err := pcapgo.NewNgWriter(f, layers.LinkTypeEthernet)
+	require.NoError(t, err)
+	for _, p := range packets {
+		require.NoError(t, w.WritePacket(captureInfo(p), p))
+	}
+	require.NoError(t, w.Flush())
+	return path
+}
+
+func captureInfo(p []byte) gopacket.CaptureInfo {
+	return gopacket.CaptureInfo{
+		Timestamp:     time.Unix(1700000000, 0),
+		CaptureLength: len(p),
+		Length:        len(p),
+	}
+}
+
+// gzipFile compresses the file at path and returns the path of the new file.
+func gzipFile(t *testing.T, path string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	gzPath := path + ".gz"
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err = gw.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	require.NoError(t, os.WriteFile(gzPath, buf.Bytes(), 0o600))
+	return gzPath
+}
+
+// memoryOutput is an output.Output that records everything written to it.
+type memoryOutput struct {
+	writes [][]byte
+}
+
+func (*memoryOutput) DialContext(context.Context) error { return nil }
+func (*memoryOutput) Close() error                      { return nil }
+
+func (m *memoryOutput) Write(b []byte) (int, error) {
+	m.writes = append(m.writes, bytes.Clone(b))
+	return len(b), nil
+}
+
+// payloads returns the recorded writes as strings.
+func (m *memoryOutput) payloads() []string {
+	out := make([]string, 0, len(m.writes))
+	for _, w := range m.writes {
+		out = append(out, string(w))
+	}
+	return out
+}
+
+func newTestRunner(t *testing.T) *pcapRunner {
+	t.Helper()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return &pcapRunner{
+		logger: zap.NewNop().Sugar(),
+		cmd:    cmd,
+	}
+}
+
+// tests
+
+func TestNewPacketReader(t *testing.T) {
+	packet := udpPacket(t, "hello")
+
+	testCases := []struct {
+		name string
+		path func(t *testing.T) string
+	}{
+		{
+			name: "pcap",
+			path: func(t *testing.T) string { return writePCAP(t, packet) },
+		},
+		{
+			name: "pcapng",
+			path: func(t *testing.T) string { return writePCAPNg(t, packet) },
+		},
+		{
+			name: "gzipped pcap",
+			path: func(t *testing.T) string { return gzipFile(t, writePCAP(t, packet)) },
+		},
+		{
+			name: "gzipped pcapng",
+			path: func(t *testing.T) string { return gzipFile(t, writePCAPNg(t, packet)) },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.Open(tc.path(t))
+			require.NoError(t, err)
+			defer f.Close()
+
+			source, linkType, err := newPacketReader(f)
+			require.NoError(t, err)
+			assert.Equal(t, layers.LinkTypeEthernet, linkType)
+
+			data, _, err := source.ReadPacketData()
+			require.NoError(t, err)
+			assert.Equal(t, packet, data)
+		})
+	}
+}
+
+func TestNewPacketReaderInvalid(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "empty", content: nil},
+		{name: "garbage", content: []byte("this is not a capture file")},
+		{name: "bad magic", content: []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "invalid")
+			require.NoError(t, os.WriteFile(path, tc.content, 0o600))
+
+			f, err := os.Open(path)
+			require.NoError(t, err)
+			defer f.Close()
+
+			_, _, err = newPacketReader(f)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSendPCAP(t *testing.T) {
+	testCases := []struct {
+		name string
+		path func(t *testing.T) string
+	}{
+		{
+			name: "pcap",
+			path: func(t *testing.T) string {
+				return writePCAP(t, udpPacket(t, "one"), udpPacket(t, "two"))
+			},
+		},
+		{
+			name: "pcapng",
+			path: func(t *testing.T) string {
+				return writePCAPNg(t, udpPacket(t, "one"), udpPacket(t, "two"))
+			},
+		},
+		{
+			name: "gzipped pcap",
+			path: func(t *testing.T) string {
+				return gzipFile(t, writePCAP(t, udpPacket(t, "one"), udpPacket(t, "two")))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &memoryOutput{}
+			require.NoError(t, newTestRunner(t).sendPCAP(tc.path(t), out))
+			assert.Equal(t, []string{"one", "two"}, out.payloads())
+		})
+	}
+}
+
+// TestSendPCAPSkipsPacketsWithoutTransportLayer verifies that packets carrying
+// no transport layer are skipped rather than failing the whole capture.
+func TestSendPCAPSkipsPacketsWithoutTransportLayer(t *testing.T) {
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		DstMAC:       net.HardwareAddr{0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b},
+		EthernetType: layers.EthernetTypeARP,
+	}
+	arp := &layers.ARP{
+		AddrType:          layers.LinkTypeEthernet,
+		Protocol:          layers.EthernetTypeIPv4,
+		HwAddressSize:     6,
+		ProtAddressSize:   4,
+		Operation:         1,
+		SourceHwAddress:   []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		SourceProtAddress: []byte{10, 0, 0, 1},
+		DstHwAddress:      []byte{0, 0, 0, 0, 0, 0},
+		DstProtAddress:    []byte{10, 0, 0, 2},
+	}
+	buf := gopacket.NewSerializeBuffer()
+	require.NoError(t, gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, eth, arp))
+
+	path := writePCAP(t, buf.Bytes(), udpPacket(t, "payload"))
+
+	out := &memoryOutput{}
+	require.NoError(t, newTestRunner(t).sendPCAP(path, out))
+	assert.Equal(t, []string{"payload"}, out.payloads())
+}
+
+// TestSendPCAPTruncated verifies that a capture cut short mid-record streams the
+// packets that were readable instead of returning an error.
+func TestSendPCAPTruncated(t *testing.T) {
+	path := writePCAP(t, udpPacket(t, "first"), udpPacket(t, "second"))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	// Drop the last few bytes so the final record is incomplete.
+	truncated := filepath.Join(t.TempDir(), "truncated.pcap")
+	require.NoError(t, os.WriteFile(truncated, raw[:len(raw)-8], 0o600))
+
+	out := &memoryOutput{}
+	require.NoError(t, newTestRunner(t).sendPCAP(truncated, out))
+	assert.Equal(t, []string{"first"}, out.payloads())
+}
+
+// TestSendPCAPCorruptRecord verifies that an unparseable record returns an error
+// rather than looping forever, which is what gopacket's PacketSource does.
+func TestSendPCAPCorruptRecord(t *testing.T) {
+	path := writePCAP(t, udpPacket(t, "first"))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	// The second record claims a capture length far beyond the snaplen.
+	corrupt := append(bytes.Clone(raw),
+		0x00, 0x00, 0x00, 0x00, // timestamp seconds
+		0x00, 0x00, 0x00, 0x00, // timestamp microseconds
+		0xff, 0xff, 0xff, 0xff, // capture length
+		0xff, 0xff, 0xff, 0xff, // original length
+	)
+	corruptPath := filepath.Join(t.TempDir(), "corrupt.pcap")
+	require.NoError(t, os.WriteFile(corruptPath, corrupt, 0o600))
+
+	out := &memoryOutput{}
+	err = newTestRunner(t).sendPCAP(corruptPath, out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read packet 2")
+}
+
+// TestSendPCAPRespectsContextCancellation verifies that a cancelled context
+// stops the capture from being streamed.
+func TestSendPCAPRespectsContextCancellation(t *testing.T) {
+	path := writePCAP(t, udpPacket(t, "one"), udpPacket(t, "two"))
+
+	r := newTestRunner(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r.cmd.SetContext(ctx)
+
+	out := &memoryOutput{}
+	require.NoError(t, r.sendPCAP(path, out))
+	assert.Empty(t, out.payloads())
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 
 	"github.com/elastic/go-concert/ctxtool/osctx"
 	"github.com/elastic/go-concert/timed"
@@ -154,14 +153,14 @@ func waitForStartSignal(ctx context.Context, opts *output.Options, logger *zap.L
 		return nil
 	}
 
-	num := unix.SignalNum(opts.StartSignal)
-	if num == 0 {
-		return fmt.Errorf("unknown signal %v", opts.StartSignal)
+	sig, err := lookupSignal(opts.StartSignal)
+	if err != nil {
+		return err
 	}
 
 	// Wait for the signal or the command context to be done.
 	logger.Sugar().Infow("Waiting for signal.", "start-signal", opts.StartSignal)
-	startCtx, _ := osctx.WithSignal(ctx, os.Signal(num))
+	startCtx, _ := osctx.WithSignal(ctx, sig)
 	<-startCtx.Done()
 	return nil
 }

--- a/internal/command/signal_unix.go
+++ b/internal/command/signal_unix.go
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V. under one or more agreements.
+// Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+//go:build !windows
+
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lookupSignal resolves a signal name, such as "SIGUSR1", to the signal it
+// names.
+func lookupSignal(name string) (os.Signal, error) {
+	num := unix.SignalNum(name)
+	if num == 0 {
+		return nil, fmt.Errorf("unknown signal %v", name)
+	}
+	return num, nil
+}

--- a/internal/command/signal_windows.go
+++ b/internal/command/signal_windows.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more agreements.
+// Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+//go:build windows
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// lookupSignal resolves a signal name, such as "SIGINT", to the signal it
+// names. Windows only supports the signals that the Go runtime emulates, so the
+// set recognized here is much smaller than on other platforms.
+func lookupSignal(name string) (os.Signal, error) {
+	switch name {
+	case "SIGINT":
+		return os.Interrupt, nil
+	case "SIGTERM":
+		return syscall.SIGTERM, nil
+	default:
+		return nil, fmt.Errorf("signal %v is not supported on windows, use SIGINT or SIGTERM", name)
+	}
+}


### PR DESCRIPTION
## Proposed commit message

```
Remove libpcap dependency and add Windows support

stream needed libpcap and cgo solely to read capture files offline, so
`go install github.com/elastic/stream@latest` failed on any machine
without libpcap and a C toolchain. Windows was hit hardest because Go
disables cgo there by default.

Replace pcap.OpenOffline with gopacket's pure Go pcapgo readers,
dispatching on the file magic to choose the pcap or pcapng reader and
decompressing gzipped captures explicitly. stream now builds with
CGO_ENABLED=0 everywhere, so libpcap is gone from the Dockerfile, the
Buildkite pipeline, and the GitHub workflows.

Windows also failed to compile because root.go used unix.SignalNum.
Move the signal name lookup behind a build tag: Unix keeps the full
set, while Windows recognizes SIGINT and SIGTERM, the only signals the
Go runtime emulates there.

Read packets in an explicit loop instead of PacketSource.Packets(),
which retries unrecognized errors in a 5ms loop and so would hang
stream indefinitely on a corrupt capture. Truncated captures are still
tolerated with a warning.

Build the published image FROM scratch now that the binary is static,
copying only the CA bundle from the builder. This drops the image from
70.5MB to 56.6MB.

Add a cross-build workflow covering six platforms plus ubuntu, windows
and macos test runs so none of this regresses unnoticed.

Validated by diffing old and new payload extraction across 55 capture
files against libpcap 1.10.5: classic pcap matches byte for byte, and
no file that libpcap could read fails with pcapgo.
```
